### PR TITLE
Build two tags

### DIFF
--- a/content/blog/build-docker-image.md
+++ b/content/blog/build-docker-image.md
@@ -329,7 +329,8 @@ Another quick suggestions from `Dave Cross` with [**reference**](https://docs.do
 
 <br>
 
-    docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/my-app:latest .
+    docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/my-app:${{ github.ref_name }} \
+                 -t ${{ secrets.DOCKER_HUB_USERNAME }}/my-app:latest .
     docker push -a ${{ secrets.DOCKER_HUB_USERNAME }}/my-app
 
 <br>


### PR DESCRIPTION
Sorry, my explanation wasn't clear. This PR includes what I was actually suggesting.

Build the image with two tags - "latest" and the actual versioned tag. Then when you run `docker push -a`, it will:

* Push the versioned tag (so you get a history of all the previous tags and people can pull old versions if they want)
* Push the "latest" tag (which overwrites the previous "latest" tag - so people can easily pull the most recent version)